### PR TITLE
Fix link to Distributed Ruby (DRb).

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ A protection proxy protects an object from unauthorized access.  To ensure metho
 ##### Remote Proxy
 Remote proxies provides access to objects which are running on remote machines.
 
-A great example of a remote proxy is [Distributed Ruby (DRb)](http://segment7.net/projects/ruby/drb/introduction.html), which allows Ruby programs to communicate over a network. With DRb, the client machines runs a proxy which handles all of the network communications behind the scenes.
+A great example of a remote proxy is [Distributed Ruby (DRb)](http://www.ruby-doc.org/stdlib-2.1.0/libdoc/drb/rdoc/DRb.html), which allows Ruby programs to communicate over a network. With DRb, the client machines runs a proxy which handles all of the network communications behind the scenes.
 
 ##### Virtual Proxy
 Virtual proxies allow us to delay the creation of an object until it is absolutely necessary.  This is useful when creating the object is computationaly expensive.


### PR DESCRIPTION
The link to DRb is currently broken. A safe and reliable option is to point it to the latest ruby documentation.

![screen shot 2014-02-15 at 22 35 19](https://f.cloud.github.com/assets/246377/2179566/758bcc96-96bb-11e3-8286-fa4d567feef5.png)
