### PR TITLE
Fix number of design patterns in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ updated to work with **ruby 2.2.0**
 
 Examples from the book **Design Patterns in Ruby** by *Russ Olsen*
 
-This book covers 14 of the original 23 GoF design patterns.
+This book covers 15 of the original 23 GoF design patterns.
 
 * [Template Method](#template-method)
 * [Strategy](#strategy)


### PR DESCRIPTION
We could update this, as there are 15 GoFdesign patterns in the book.